### PR TITLE
fix: missing return (Leaderboard)

### DIFF
--- a/BPBackendDjango/BPBackendDjango/Views/leaderboardviews.py
+++ b/BPBackendDjango/BPBackendDjango/Views/leaderboardviews.py
@@ -17,7 +17,7 @@ class ListLeaderboardView(APIView):
                 'description': 'Token is not valid',
                 'data': {}
             }
-            Response(data)
+            return Response(data)
 
         info = token['info']
 


### PR DESCRIPTION
if token is invalid, Response was created but not returned